### PR TITLE
Context blocks for DSL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,10 +4,6 @@
 
 - RSpec style pending?
 
-- context blocks
-  - As a simple prefix for test name
-  - No scoped setup/teardown, need to explicitly reject that.
-
 - Distributed queue (ci-queue style).
   - Other?
 

--- a/fixtures/context/callbacks_test.rb
+++ b/fixtures/context/callbacks_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TestedApp
+  class TestCase < Megatest::Test
+    # base test class where to put helpers and such
+  end
+
+  class CallbacksTest < TestCase
+    context "some context" do
+      setup do
+        # illegal
+      end
+    end
+  end
+end

--- a/fixtures/context/context_test.rb
+++ b/fixtures/context/context_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module TestedApp
+  class TestCase < Megatest::Test
+    # base test class where to put helpers and such
+  end
+
+  class ContextTest < TestCase
+    tag some_tag: 0
+
+    context "some context", some_tag: 1 do
+      test "the truth" do
+        assert true
+      end
+
+      test "the lie", some_tag: 2 do
+        assert false
+      end
+
+      context "some more context", some_tag: 3, focus: true do
+        test "the unexpected", some_tag: 4 do
+          1 + nil
+        end
+      end
+    end
+
+    context "something else" do
+      test "the void" do
+      end
+    end
+  end
+end

--- a/lib/megatest/dsl.rb
+++ b/lib/megatest/dsl.rb
@@ -25,6 +25,10 @@ module Megatest
       ::Megatest.registry.suite(self).add_tags(kwargs)
     end
 
+    def context(name, tags = nil, &block)
+      ::Megatest.registry.suite(self).with_context(name, tags, &block)
+    end
+
     def method_added(name)
       super
       if name.start_with?("test_")

--- a/test/megatest/selector_test.rb
+++ b/test/megatest/selector_test.rb
@@ -38,6 +38,8 @@ module Megatest
       expected = [
         "fixtures/callbacks/callbacks_test.rb",
         "fixtures/compat/compat_test.rb",
+        "fixtures/context/callbacks_test.rb",
+        "fixtures/context/context_test.rb",
         "fixtures/crash/crash_test.rb",
         "fixtures/errors/isolated_test.rb",
         "fixtures/inheritance/inheritance_test.rb",
@@ -51,14 +53,16 @@ module Megatest
     def test_directory_path_shuffling
       selector = Selector.parse(["fixtures", "!", "fixtures/simple", "fixtures/simple/error_test.rb"])
       expected = [
+        "fixtures/simple/error_test.rb",
         "fixtures/compat/compat_test.rb",
-        "fixtures/large/large_test.rb",
+        "fixtures/errors/isolated_test.rb",
         "fixtures/callbacks/callbacks_test.rb",
+        "fixtures/large/large_test.rb",
+        "fixtures/context/callbacks_test.rb",
         "fixtures/tags/tagged_test.rb",
         "fixtures/crash/crash_test.rb",
+        "fixtures/context/context_test.rb",
         "fixtures/inheritance/inheritance_test.rb",
-        "fixtures/errors/isolated_test.rb",
-        "fixtures/simple/error_test.rb",
       ]
       assert_equal expected, relative(selector.paths(random: Random.new(42)))
     end

--- a/test/megatest_test.rb
+++ b/test/megatest_test.rb
@@ -82,6 +82,30 @@ class MegatestTest < MegaTestCase
     assert_predicate result, :failed?
   end
 
+  def test_context
+    load_fixture("context/context_test.rb")
+    test_cases = @registry.test_cases.sort
+    assert_equal <<~CLASSES.strip, test_cases.map(&:id).join("\n")
+      TestedApp::ContextTest#some context some more context the unexpected
+      TestedApp::ContextTest#some context the lie
+      TestedApp::ContextTest#some context the truth
+      TestedApp::ContextTest#something else the void
+    CLASSES
+    assert_equal [
+      { some_tag: 4, focus: true },
+      { some_tag: 2 },
+      { some_tag: 1 },
+      { some_tag: 0 },
+    ], test_cases.map(&:tags)
+  end
+
+  def test_context_callbacks
+    error = assert_raises(Megatest::Error) do
+      load_fixture("context/callbacks_test.rb")
+    end
+    assert_match "setup", error.message
+  end
+
   def test_successful_run
     load_fixture("simple/simple_test.rb")
 


### PR DESCRIPTION
Allows grouping of tests by simply prefixing the name of the context to the test case name.
    
Setup/teardown blocks are not allowed.
    
The goal is to help organizing tests by logical groups, but not to allow constructs that make individual tests harder to read.

