### PR TITLE
Console improvements

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,8 +4,15 @@
 require "bundler/setup"
 require "megatest"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
+def test!
+  queue = Megatest.config.build_queue
+  queue.populate(Megatest.registry.test_cases)
+  executor = Megatest::Executor.new(Megatest.config, $stdout)
+  executor.run(queue, [Megatest::Reporters::SimpleReporter.new(Megatest.config, $stdout)])
+  queue.success?
+end
 
-require "irb"
-IRB.start(__FILE__)
+Megatest.with_registry do
+  require "irb"
+  IRB.start(__FILE__)
+end

--- a/lib/megatest/config.rb
+++ b/lib/megatest/config.rb
@@ -214,10 +214,9 @@ module Megatest
       @differ&.call(expected, actual)
     end
 
-    def pretty_print(object)
+    def render_object(object)
       @pretty_printer.pretty_print(object)
     end
-    alias_method :pp, :pretty_print
 
     # We always return a new generator with the same seed as to
     # best reproduce remote builds locally if the same seed is given.

--- a/lib/megatest/differ.rb
+++ b/lib/megatest/differ.rb
@@ -36,7 +36,7 @@ module Megatest
     private
 
     def pp(object)
-      @config.pretty_print(object)
+      @config.render_object(object)
     end
 
     def object_diff(expected, expected_inspect, actual_inspect)

--- a/lib/megatest/runtime.rb
+++ b/lib/megatest/runtime.rb
@@ -144,7 +144,7 @@ module Megatest
     end
 
     def pp(object)
-      @config.pretty_print(object)
+      @config.render_object(object)
     end
 
     def diff(expected, actual)


### PR DESCRIPTION
Just wanted to try out writing a test class in the console and run the tests, also found that having a method called `pretty_print` on `Megatest::Config` wasn't super nice for debugging in a console.

```console
$ bin/console                                                                                                                                                                                                                            
?> class FooTest < Megatest::Test
?>   test "fails" do
?>     assert false
?>   end
>> end
=> #<Megatest::State::BlockTest: FooTest#fails @ (irb):2>
>> test!
Running 1 test cases with --seed 60698

F

  1) Failure: FooTest#fails

  Expected false to be truthy

  (irb):3:in `block in <class:FooTest>'

megatest (irb):2

Ran 1 cases, 1 assertions, 1 failures, 0 errors, 0 retries, 0 skips
=> false
```

I believe the `test!` method for the console (modeled after `reload!` in Rails) shows that we could refactor the classes a bit but I'm not sure which way exactly yet:
* we could have a registry by default to avoid having to wrap any code defining tests with `Megatest.with_registry`
* `build_queue` could be on `Megatest` directly, and maybe the logic around distributed sharded could be done there
* building the reporters could be done by the config and moved out of CLI (`verbose` and `junit` could be part of the config too, as well as `@out` and `@err`)
* `CLI#executor` could be moved to `Megatest`