### PR TITLE
Some edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,55 @@ Megatest is a test-unit like framework with a focus on usability, and designed w
 
 ## Installation
 
-Install the gem and add to the application's Gemfile by executing:
+Install the gem and add it to the application's Gemfile by executing:
 
     $ bundle add megatest
 
 ## Usage
 
+### Special Files And Directories
+
+By default, tests are assumed to live in the `test` directory. If present, the
+optional files `test/test_config.rb` and `test/test_helper.rb` are loaded
+automatically, and in that order.
+
+#### test/test_config.rb
+
+The `megatest` CLI offers options to override default settings, but if you'd
+like to have some always set, please do so in the optional
+`test/test_config.rb`:
+
+```ruby
+# test/test_config.rb
+
+Megatest.config do |config|
+  # See Megatest::Config.
+end
+```
+
+#### test/test_helper.rb
+
+The optional file `test/test_helper.rb` is meant to centralize dependencies and
+define test helpers:
+
+```ruby
+# test/test_helper.rb
+
+require "some_dependency"
+
+module MyApp
+  class Test < Megatest::Test
+    def some_helper(arg)
+    end
+  end
+end
+```
+
 ### Writing Tests
 
 Test suites are Ruby classes that inherit from `Megatest::Test`.
 
-Test cases are be defined with the `test` macro, or for compatibility with existing test suites,
+Test cases are defined with the `test` macro, or for compatibility with existing test suites,
 by defining a method starting with `test_`.
 
 All the classic `test-unit` and `minitest` assertion methods are available:
@@ -37,24 +75,7 @@ class SomeTest < MyApp::Test
 end
 ```
 
-By convention, all the `test_helper.rb` files are automatically loaded,
-which allows to centralize dependencies and define some helpers.
-
-```ruby
-# test/test_helper.rb
-
-require "some_dependency"
-
-module MyApp
-  class Test < Megatest::Test
-
-    def some_helper(arg)
-    end
-  end
-end
-```
-
-It also allow to define test inside `context` blocks, to make it easier to group
+Megatest also allows to define tests inside `context` blocks, to make it easier to group
 related tests together and have them share a common name prefix.
 
 ```ruby
@@ -78,7 +99,7 @@ blocks, nor their own namespaces.
 
 ### Command Line
 
-Contrary to many alternatives, `megatest` provide a convenient CLI interface to easily run specific tests.
+Contrary to many alternatives, `megatest` provides a convenient CLI interface to easily run specific tests.
 
 Run all tests in a directory:
 
@@ -109,7 +130,7 @@ For more detailed usage, run `megatest --help`.
 
 ### CI Parallelization
 
-Megatest offer multiple feature to allow running test suites in parallel across
+Megatest offers multiple features to allow running test suites in parallel across
 many CI jobs.
 
 #### Sharding
@@ -137,8 +158,8 @@ will be automatically inferred from the environment.
 
 A more efficient way to parallelize tests on CI is to use a Redis server to act as a queue.
 
-This allow to efficiently and dynamically ensure a near perfect test case balance across all
-the workers. And if for some reason one of the worker is lost or crashes, no test is lost,
+This allows to efficiently and dynamically ensure a near perfect test case balance across all
+the workers. And if for some reason one of the workers is lost or crashes, no test is lost,
 which for builds with hundreds of parallel jobs, is essential for stability.
 
 ```yaml

--- a/lib/megatest.rb
+++ b/lib/megatest.rb
@@ -38,7 +38,7 @@ module Megatest
         ::Warning[:deprecated] = true
       end
 
-      # We initiale the seed in case there is some Random use
+      # We initialize the seed in case there is some Random use
       # at code loading time.
       Random.srand(config.seed)
     end


### PR DESCRIPTION
Yo! Just some edits.

There are some easy typos and stuff, and a new section about `test/test_config.rb` and `test/test_helper.rb`. That was motivated by

> By convention, all the `test_helper.rb` files are automatically loaded

I was like, all? which all? The README does not even mention a default `test` directory. And, besides, does that mean there can be more directories? Where are they? etc.

Indeed, I see there's this concept of `main_paths`, but at 00:48 AM I have not connected the dots yet to understand them in relation to `test_config.rb` and `test_helper.rb`. Probably the edit in this patch, which covers the default common use case (I suppose), can be improved.

I am not 100% the way the new docs are worded match what you have in mind, let's say this is an optimistic patch for your review :).