### PR TITLE
Don't divide by zero when summarizing results

### DIFF
--- a/lib/megatest/reporters.rb
+++ b/lib/megatest/reporters.rb
@@ -104,7 +104,7 @@ module Megatest
 
         # In case of failure we'd rather not print slow tests
         # as it would blur the output.
-        if queue.success?
+        if queue.success? && !summary.results.empty?
           sorted_results = summary.results.sort_by(&:duration)
           size = sorted_results.size
           average = sorted_results.sum(&:duration) / size


### PR DESCRIPTION
If tests are sharded and a worker ran 0 tests, this part of the summary currently fails.

```console
$ bin/megatest --workers-count 100 --worker-id 99 fixtures/simple
```