### PR TITLE
Automatic parallelization

### DIFF
--- a/lib/megatest/cli.rb
+++ b/lib/megatest/cli.rb
@@ -79,16 +79,15 @@ module Megatest
       @parser = build_parser
       @parser.parse!(@argv)
       @argv.shift if @argv.first == "--"
+      @queue = @config.build_queue
       @config
     end
 
     def run_tests
-      queue = @config.build_queue
-
-      if queue.distributed?
+      if @queue.distributed?
         raise InvalidArgument, "Distributed queues require a build-id" unless @config.build_id
         raise InvalidArgument, "Distributed queues require a worker-id" unless @config.worker_id
-      elsif queue.sharded?
+      elsif @queue.sharded?
         unless @config.valid_worker_index?
           raise InvalidArgument, "Splitting the queue requires a worker-id lower than workers-count, got: #{@config.worker_id.inspect}"
         end
@@ -104,42 +103,38 @@ module Megatest
         return 1
       end
 
-      queue.populate(test_cases)
-      executor.run(queue, default_reporters)
-      queue.success? ? 0 : 1
+      @queue.populate(test_cases)
+      executor.run(@queue, default_reporters)
+      @queue.success? ? 0 : 1
     end
 
     def report
-      queue = @config.build_queue
-
-      raise InvalidArgument, "Only distributed queues can be summarized" unless queue.distributed?
+      raise InvalidArgument, "Only distributed queues can be summarized" unless @queue.distributed?
       raise InvalidArgument, "Distributed queues require a build-id" unless @config.build_id
       raise InvalidArgument, @argv.join(" ") unless @argv.empty?
 
       Megatest.load_config(@argv)
 
-      QueueReporter.new(@config, queue, @out).run(default_reporters) ? 0 : 1
+      QueueReporter.new(@config, @queue, @out).run(default_reporters) ? 0 : 1
     end
 
     def bisect_tests
       require "megatest/multi_process"
-
-      queue = @config.build_queue
-      raise InvalidArgument, "Distributed queues can't be bisected" if queue.distributed?
+      raise InvalidArgument, "Distributed queues can't be bisected" if @queue.distributed?
 
       @config.selectors = Selector.new(@config).parse(@argv)
       Megatest.load_config(@config)
       Megatest.init(@config)
       test_cases = Megatest.load_tests(@config)
-      queue.populate(test_cases)
-      candidates = queue.dup
+      @queue.populate(test_cases)
+      candidates = @queue.dup
 
       if test_cases.empty?
         @err.puts "No tests to run"
         return 1
       end
 
-      unless failure = find_failing_test(queue)
+      unless failure = find_failing_test
         @err.puts "No failing test"
         return 1
       end
@@ -172,13 +167,13 @@ module Megatest
       reporters
     end
 
-    def find_failing_test(queue)
+    def find_failing_test
       @config.max_consecutive_failures = 1
       @config.jobs_count = 1
 
       executor = MultiProcess::Executor.new(@config.dup, @out)
-      executor.run(queue, default_reporters)
-      queue.summary.failures.first
+      executor.run(@queue, default_reporters)
+      @queue.summary.failures.first
     end
 
     def bisect_queue(queue, failing_test_id)

--- a/lib/megatest/cli.rb
+++ b/lib/megatest/cli.rb
@@ -27,7 +27,7 @@ module Megatest
 
     undef_method :puts, :print # Should only use @out.puts or @err.puts
 
-    RUNNERS = {
+    COMMANDS = {
       "bisect" => :bisect,
       "report" => :report,
       "run" => :run,
@@ -40,14 +40,14 @@ module Megatest
       @processes = nil
       @config = Config.new(env)
       @program_name = @config.program_name = program_name
-      @runner = nil
+      @command = nil
       @verbose = false
       @junit = false
     end
 
     def run
       configure
-      case @runner
+      case @command
       when :report
         report
       when nil, :run
@@ -71,12 +71,12 @@ module Megatest
     def configure
       Megatest.running = true
 
-      if @runner = RUNNERS[@argv.first]
+      if @command = COMMANDS[@argv.first]
         @argv.shift
       end
 
       Megatest.config = @config
-      @parser = build_parser(@runner)
+      @parser = build_parser(@command)
       @parser.parse!(@argv)
       @argv.shift if @argv.first == "--"
       @config
@@ -260,9 +260,9 @@ module Megatest
       end
     end
 
-    def build_parser(runner)
+    def build_parser(command)
       OptionParser.new do |opts|
-        case runner
+        case command
         when :report
           opts.banner = "Usage: #{@program_name} report [options]"
         when :run
@@ -289,7 +289,7 @@ module Megatest
           opts.separator "\t\t\t  $ #{@program_name} bisect --queue path/to/test_order.log"
           opts.separator ""
         end
-        runner = :run if runner.nil?
+        command = :run if command.nil?
 
         opts.separator ""
         opts.separator "Options:"
@@ -313,13 +313,13 @@ module Megatest
           @junit = path
         end
 
-        if %i[run bisect].include?(runner)
+        if %i[run bisect].include?(command)
           opts.on("--seed SEED", Integer, "The seed used to define run order.") do |seed|
             @config.seed = seed
           end
         end
 
-        if runner == :run
+        if command == :run
           opts.on("-j", "--jobs [JOBS]", Integer, "Number of processes to use. Defaults to the number of processors.") do |jobs|
             @config.jobs_count = jobs || :number_of_processors
           end
@@ -346,13 +346,13 @@ module Megatest
           @config.queue_url = queue_url
         end
 
-        if %i[run report].include?(runner)
+        if %i[run report].include?(command)
           opts.on("--build-id ID", String, "Unique identifier for the CI build.") do |build_id|
             @config.build_id = build_id
           end
         end
 
-        if runner == :run
+        if command == :run
           opts.on("--worker-id ID", String, "Unique identifier for the CI job.") do |worker_id|
             @config.worker_id = worker_id
           end

--- a/lib/megatest/cli.rb
+++ b/lib/megatest/cli.rb
@@ -50,7 +50,7 @@ module Megatest
       case @command
       when :report
         report
-      when nil, :run
+      when :run
         run_tests
       when :bisect
         bisect_tests
@@ -76,7 +76,7 @@ module Megatest
       end
 
       Megatest.config = @config
-      @parser = build_parser(@command)
+      @parser = build_parser
       @parser.parse!(@argv)
       @argv.shift if @argv.first == "--"
       @config
@@ -260,9 +260,9 @@ module Megatest
       end
     end
 
-    def build_parser(command)
+    def build_parser
       OptionParser.new do |opts|
-        case command
+        case @command
         when :report
           opts.banner = "Usage: #{@program_name} report [options]"
         when :run
@@ -289,7 +289,7 @@ module Megatest
           opts.separator "\t\t\t  $ #{@program_name} bisect --queue path/to/test_order.log"
           opts.separator ""
         end
-        command = :run if command.nil?
+        @command ||= :run
 
         opts.separator ""
         opts.separator "Options:"
@@ -313,13 +313,13 @@ module Megatest
           @junit = path
         end
 
-        if %i[run bisect].include?(command)
+        if %i[run bisect].include?(@command)
           opts.on("--seed SEED", Integer, "The seed used to define run order.") do |seed|
             @config.seed = seed
           end
         end
 
-        if command == :run
+        if @command == :run
           opts.on("-j", "--jobs [JOBS]", Integer, "Number of processes to use. Defaults to the number of processors.") do |jobs|
             @config.jobs_count = jobs || :number_of_processors
           end
@@ -346,13 +346,13 @@ module Megatest
           @config.queue_url = queue_url
         end
 
-        if %i[run report].include?(command)
+        if %i[run report].include?(@command)
           opts.on("--build-id ID", String, "Unique identifier for the CI build.") do |build_id|
             @config.build_id = build_id
           end
         end
 
-        if command == :run
+        if @command == :run
           opts.on("--worker-id ID", String, "Unique identifier for the CI job.") do |worker_id|
             @config.worker_id = worker_id
           end

--- a/lib/megatest/cli.rb
+++ b/lib/megatest/cli.rb
@@ -80,6 +80,7 @@ module Megatest
       @parser.parse!(@argv)
       @argv.shift if @argv.first == "--"
       @queue = @config.build_queue
+      @config.parallelize_maybe if @command == :run && !@queue.distributed? && !@queue.sharded?
       @config
     end
 

--- a/lib/megatest/cli.rb
+++ b/lib/megatest/cli.rb
@@ -102,6 +102,8 @@ module Megatest
       if test_cases.empty?
         @err.puts "No tests to run"
         return 1
+      elsif test_cases.size == 1
+        @config.jobs_count = 1
       end
 
       @queue.populate(test_cases)

--- a/lib/megatest/config.rb
+++ b/lib/megatest/config.rb
@@ -153,7 +153,7 @@ module Megatest
       @build_id = nil
       @worker_id = nil
       @workers_count = 1
-      @jobs_count = 1
+      @jobs_count = nil
       @colors = nil # auto
       @before_fork_callbacks = []
       @global_setup_callbacks = []
@@ -197,7 +197,12 @@ module Megatest
           @jobs_count = 1
         end
       end
-      @jobs_count
+      @jobs_count ||= 1
+    end
+
+    def parallelize_maybe
+      @jobs_count ||= :number_of_processors if Megatest.fork?
+      self
     end
 
     def worker_id=(id)

--- a/lib/megatest/reporters.rb
+++ b/lib/megatest/reporters.rb
@@ -128,7 +128,7 @@ module Megatest
           end
         end
 
-        @out.puts format(
+        @out.print format(
           "Ran %d cases, %d assertions, %d failures, %d errors, %d retries, %d skips",
           summary.runs_count,
           summary.assertions_count,
@@ -137,6 +137,8 @@ module Megatest
           summary.retries_count,
           summary.skips_count,
         )
+        @out.print(" in #{@config.jobs_count} processes") if @config.jobs_count > 1
+        @out.puts
       end
 
       def s(duration)

--- a/test/megatest/autorun_test.rb
+++ b/test/megatest/autorun_test.rb
@@ -4,7 +4,7 @@ module Megatest
   class AutorunTest < MegaTestCase
     test "running with ruby works" do
       test_file = fixture("autorun/some_test.rb")
-      output = `ruby #{test_file}`
+      output = `ruby #{test_file} --jobs=1`
       assert_includes output, "Failure: SomeTest#something"
       assert_includes output, "Expected: 4"
       assert_includes output, "Actual: 2"

--- a/test/megatest/cli_test.rb
+++ b/test/megatest/cli_test.rb
@@ -39,6 +39,15 @@ module Megatest
       end
     end
 
+    def test_jobs_count_for_single_test
+      stub(Etc, :nprocessors, -> { 3 }) do
+        stub_any_instance_of(Megatest::Config, :cgroups_cpu_quota)
+        cli = new_cli(fixture("simple/simple_test.rb:9"))
+        assert_equal 0, cli.run
+        assert_equal 1, cli.instance_variable_get(:@config).jobs_count
+      end
+    end
+
     if Megatest.fork?
       def test_jobs_count_fork_available
         stub(Etc, :nprocessors, -> { 3 }) do

--- a/test/megatest/cli_test.rb
+++ b/test/megatest/cli_test.rb
@@ -10,7 +10,7 @@ module Megatest
     end
 
     def test_execute_directory
-      cli = new_cli(fixture("simple/"))
+      cli = new_cli(fixture("simple/"), "--jobs=1")
       assert_equal 1, cli.run
     end
 
@@ -21,7 +21,7 @@ module Megatest
     end
 
     def test_custom_test_glob
-      cli = new_cli(fixture("custom_glob/"))
+      cli = new_cli(fixture("custom_glob/"), "--jobs=1")
 
       assert_equal 0, cli.run
 
@@ -33,7 +33,9 @@ module Megatest
       stub(Etc, :nprocessors, -> { test.flunk "Etc.nprocessors was unexpectedly called" }) do
         assert_equal 1, config("--jobs=1").jobs_count
         assert_equal 42, config("--jobs=42").jobs_count
-        assert_equal 1, config.jobs_count
+        # sharded and distributed queue runs are not automatically parallelized
+        assert_equal 1, config("--worker-id=1", "--workers-count=2").jobs_count
+        assert_equal 1, config("--queue=redis://[100::]:6379/1").jobs_count
       end
     end
 
@@ -42,6 +44,7 @@ module Megatest
         stub(Etc, :nprocessors, -> { 3 }) do
           stub_any_instance_of(Megatest::Config, :cgroups_cpu_quota)
           assert_equal 3, config("--jobs").jobs_count
+          assert_equal 3, config.jobs_count
         end
       end
     else


### PR DESCRIPTION
Builds on #25 

When not using sharding or a distributed queue, automatically parallelize as if `--jobs $(nproc)` was used (or just `--jobs` with #25).