### PR TITLE
Remove unused block warning

### DIFF
--- a/lib/megatest/runner.rb
+++ b/lib/megatest/runner.rb
@@ -10,9 +10,7 @@ module Megatest
 
     def execute(test_case)
       if test_case.tag(:isolated)
-        isolate(test_case) do
-          run(test_case)
-        end
+        isolate(test_case)
       else
         run(test_case)
       end
@@ -23,7 +21,7 @@ module Megatest
         read, write = IO.pipe.each(&:binmode)
         pid = Process.fork do
           read.close
-          result = yield
+          result = run(test_case)
           Marshal.dump(result, write)
           write.close
           # We don't want to run at_exit hooks the app may have


### PR DESCRIPTION
The in-process call to `#run` goes through a block while the isolated version does not, which results in a unused block warning.

	$ RUBYOPT=-W:strict_unused_block NO_FORK=1 bin/megatest fixtures/errors:@isolated >/dev/null
	lib/megatest/runner.rb:13: warning: the block passed to 'Megatest::Runner#isolate' defined at lib/megatest/runner.rb:43 may be ignored