### PR TITLE
Improve retries rendering to be actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Improve rendering of retried failures so they're actionable.
+
 ## [0.7.0] - 2026-03-21
 
 - Automatic parallelization using cgroups or nprocs.

--- a/lib/megatest/reporters.rb
+++ b/lib/megatest/reporters.rb
@@ -44,9 +44,9 @@ module Megatest
         str = +str
         str << "\n"
 
-        if result.error?
+        if result.error?(include_retry: true)
           str << @out.indent("#{result.failure.cause.name}: #{@out.colored(result.failure.cause.message)}\n")
-        elsif result.failed?
+        elsif result.failure?(include_retry: true)
           str << @out.indent(@out.colored(result.failure.message.to_s))
         end
         str << "\n" unless str.end_with?("\n")

--- a/lib/megatest/state.rb
+++ b/lib/megatest/state.rb
@@ -673,12 +673,12 @@ module Megatest
       !@failures.empty?
     end
 
-    def failure?
-      !@retried && !skipped? && !@failures.empty? && @failures.first&.name != UnexpectedError.name
+    def failure?(include_retry: false)
+      (include_retry || !@retried) && !skipped? && !@failures.empty? && @failures.first&.name != UnexpectedError.name
     end
 
-    def error?
-      !@retried && @failures.first&.name == UnexpectedError.name
+    def error?(include_retry: false)
+      (include_retry || !@retried) && @failures.first&.name == UnexpectedError.name
     end
 
     def lost?


### PR DESCRIPTION
Before:

```
  2) Retried: TestedApp::BeforeSetupTest#ok

  Unexpected exception

  fixtures/simple/error_test.rb:58:in 'Integer#+'
  fixtures/simple/error_test.rb:58:in 'TestedApp::BeforeSetupTest#before_setup'
```

After:

```
  1) Retried: TestedApp::BeforeSetupTest#ok

  TypeError: nil can't be coerced into Integer
  
        1 + nil
            ^^^

  fixtures/simple/error_test.rb:58:in 'Integer#+'
  fixtures/simple/error_test.rb:58:in 'TestedApp::BeforeSetupTest#before_setup'
```
